### PR TITLE
feat: display flash when updating person (via Turbo)

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -15,6 +15,7 @@ class PeopleController < ApplicationController
   def update
     respond_to do |format|
       if @person.update(person_params)
+        format.turbo_stream
         format.html do
           redirect_to counting_people_url,
                       notice: I18n.t('people.update.notice')

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -1,5 +1,5 @@
-<%= turbo_frame_tag dom_id(person) do %>
-  <div id="<%= dom_id person %>" class="mt-5">
+<%= turbo_frame_tag dom_id(person), data: { turbo_cache: false } do %>
+  <div class="mt-5">
     <div class="flex gap-3">
       <div class="leading-none">
         <time class="block text-lg font-bold text-white"><%= person.created_at.to_fs(:time) %></time>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -1,7 +1,8 @@
 <div class="mt-8 px-5">
   <h1><%= t('people.edit.title') %></h1>
 
-  <%= turbo_frame_tag dom_id(@person) do %>
+  <%# Disabling the Turbo cache here is not ideal, but we want to prevent the form from flashing when returning from a different route: %>
+  <%= turbo_frame_tag dom_id(@person), data: { turbo_cache: false } do %>
     <%= form_with(model: @person, url: counting_person_url(@counting, @person), method: :patch, id: 'person_form') do |form| %>
       <div class="mt-5">
         <%= form.label :pet_count %>

--- a/app/views/people/update.turbo_stream.erb
+++ b/app/views/people/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%# Upon update we append to the flash list a new flash item %>
+<%= turbo_stream.append "flash", partial: "shared/flash", locals: { type: :notice, message: t('people.update.notice') } %>
+
+<%# Upon update we replace the turbo_frame_tag with the dom_id(@person) with the display of the person partial with data of the just updated @person %>
+<%= turbo_stream.replace dom_id(@person), partial: "people/person", locals: { person: @person } %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -4,6 +4,8 @@
 
 <li
   class="px-5 py-2 font-medium <%= color_classes %>"
+  <%# We need this flash item to not be cached by Turbo in order to not have it flash (pun not intended) later: %>
+  data-turbo-cache="false"
 >
   <%= message %>
 </li>


### PR DESCRIPTION
It is possible to update a `Person` via a Turbo-driven interaction that replaces the person partial with the `edit` view. We need to handle this with a Turbo stream to display the flash message at the right time. This also requires manually replacing the `edit` view with the person partial upon successful `update`.