### PR TITLE
refactor(countings): move filtering to scopes

### DIFF
--- a/app/controllers/countings_controller.rb
+++ b/app/controllers/countings_controller.rb
@@ -9,7 +9,7 @@ class CountingsController < ApplicationController
       if params[:status].present? && counting_status == 'past'
         Counting.past
       else
-        Counting.future
+        Counting.upcoming
       end
     @counting_status = counting_status
   end

--- a/app/models/counting.rb
+++ b/app/models/counting.rb
@@ -13,5 +13,5 @@ class Counting < ApplicationRecord
   has_many :people, dependent: :destroy
 
   scope :past, -> { where('ends_at < ?', DateTime.now) }
-  scope :future, -> { where('ends_at > ?', DateTime.now) }
+  scope :upcoming, -> { where('ends_at > ?', DateTime.now) }
 end


### PR DESCRIPTION
This PR moves the filtering of past and upcoming countings to a model scope. Previously this was done in the controller.