### PR TITLE
chore: remove unneceesary Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,11 +39,7 @@ Lint/MissingSuper:
   Exclude:
     - app/components/**/*
 Style/Documentation:
-  Exclude:
-    - app/components/**/*
-    - test/**/*
-    - app/controllers/**/*
-    - app/helpers/**/*
+  Enabled: false
 Metrics/ParameterLists:
   Exclude: 
     - app/components/**/*

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
-# Application controller
 class ApplicationController < ActionController::Base
   before_action :switch_locale
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,2 @@
-# Application helper
 module ApplicationHelper
 end

--- a/app/models/age_group.rb
+++ b/app/models/age_group.rb
@@ -1,4 +1,3 @@
-# AgeGroup model
 class AgeGroup < ApplicationRecord
   validates :min_age, presence: true
   validates :max_age,

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,6 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module CountingsApp
-  # Application config
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0


### PR DESCRIPTION
Comments are only welcome on a per-class basis. Requiring them by default only adds noise.