### PR TITLE
feat(#76): make countees downloadable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'activerecord-postgis-adapter'
 # For creating the District seeds (geojson conversion to Active Record column)
 gem 'rgeo-geojson'
 
+# Pagination library
+gem 'pagy', '~> 5.10'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (5.10.1)
+      activesupport
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -415,6 +417,7 @@ DEPENDENCIES
   jbuilder
   letter_opener (~> 1.8, >= 1.8.1)
   lookbook (~> 1.1.0)
+  pagy (~> 5.10)
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -144,6 +144,40 @@
 .field_with_errors {
   @apply !text-danger;
 }
-.field_with_errors [type="text"], .field_with_errors [type="number"] {
+.field_with_errors [type="text"],
+.field_with_errors [type="number"] {
   @apply !border-danger;
+}
+
+/*
+------------------------------------------------
+  Pagy customizations
+------------------------------------------------
+*/
+.pagy-nav,
+.pagy-nav-js {
+  @apply flex space-x-2;
+}
+
+.pagy-nav .page a,
+.pagy-nav .page.active,
+.pagy-nav .page.prev.disabled,
+.pagy-nav .page.next.disabled,
+.pagy-nav-js .page a,
+.pagy-nav-js .page.active,
+.pagy-nav-js .page.prev.disabled,
+.pagy-nav-js .page.next.disabled {
+  @apply block px-3 py-1 text-blue-300 bg-transparent border border-blue-600;
+}
+
+.pagy-nav .page.prev.disabled,
+.pagy-nav .page.next.disabled,
+.pagy-nav-js .page.prev.disabled,
+.pagy-nav-js .page.next.disabled {
+  @apply text-blue-400 cursor-default;
+}
+
+.pagy-nav .page.active,
+.pagy-nav-js .page.active {
+  @apply text-blue-900 cursor-default bg-white;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   before_action :switch_locale
 
   def switch_locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,9 @@ class ApplicationController < ActionController::Base
   before_action :switch_locale
 
   def switch_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+    locale = params[:locale] || I18n.default_locale
+    I18n.locale = locale
+    @pagy_locale = locale
   end
 
   def default_url_options

--- a/app/controllers/countees_controller.rb
+++ b/app/controllers/countees_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class CounteesController < ApplicationController
   before_action :authenticate_admin!, only: %i[index destroy]
   before_action :authenticate_user!, only: %i[new create]
@@ -7,6 +9,22 @@ class CounteesController < ApplicationController
 
   def index
     @countees = @counting.countees.order('created_at DESC').limit(25)
+  end
+
+  def all
+    @countees = @counting.countees.all
+
+    # TODO: build CSV-safe array of countees with a PORO instead of in the template
+
+    respond_to do |format|
+      format.csv do
+        response.headers['Content-Type'] = 'text/csv'
+
+        # TODO: better file name?
+        response.headers['Content-Disposition'] =
+          "attachment; filename=counting-#{@counting.id}_all-countees.csv"
+      end
+    end
   end
 
   def new

--- a/app/controllers/countees_controller.rb
+++ b/app/controllers/countees_controller.rb
@@ -14,8 +14,6 @@ class CounteesController < ApplicationController
   def all
     @countees = @counting.countees.all
 
-    # TODO: build CSV-safe array of countees with a PORO instead of in the template
-
     respond_to do |format|
       format.csv do
         response.headers['Content-Type'] = 'text/csv'

--- a/app/controllers/countees_controller.rb
+++ b/app/controllers/countees_controller.rb
@@ -19,10 +19,8 @@ class CounteesController < ApplicationController
     respond_to do |format|
       format.csv do
         response.headers['Content-Type'] = 'text/csv'
-
-        # TODO: better file name?
         response.headers['Content-Disposition'] =
-          "attachment; filename=counting-#{@counting.id}_all-countees.csv"
+          "attachment; filename=counting-#{@counting.id}_countees.csv"
       end
     end
   end

--- a/app/controllers/countees_controller.rb
+++ b/app/controllers/countees_controller.rb
@@ -8,7 +8,7 @@ class CounteesController < ApplicationController
   before_action :set_countee, only: %i[destroy]
 
   def index
-    @countees = @counting.countees.order('created_at DESC').limit(25)
+    @pagy, @countees = pagy(@counting.countees.order('created_at DESC'))
   end
 
   def all

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/views/countees/all.csv.erb
+++ b/app/views/countees/all.csv.erb
@@ -1,0 +1,2 @@
+<%= CSV.generate_line ['ID', 'Zählung', 'Bezirk', 'Gender', 'Altersgruppe', 'Anzahl an Haustieren', 'Erstellungsdatum', 'Zuletzt bearbeitet'] %>
+<% @countees.each do |countee| %><%= CSV.generate_line([countee.id, countee.counting.title, countee.district.name, countee.gender.present? ? countee.gender.label : nil, countee.age_group.present? ? countee.age_group.label : nil, countee.pet_count, countee.created_at, countee.updated_at]) %><% end %>

--- a/app/views/countees/all.csv.erb
+++ b/app/views/countees/all.csv.erb
@@ -1,2 +1,2 @@
-<%= CSV.generate_line ['ID', 'Zählung', 'Bezirk', 'Gender', 'Altersgruppe', 'Anzahl an Haustieren', 'Erstellungsdatum', 'Zuletzt bearbeitet'] %>
-<% @countees.each do |countee| %><%= CSV.generate_line([countee.id, countee.counting.title, countee.district.name, countee.gender.present? ? countee.gender.label : nil, countee.age_group.present? ? countee.age_group.label : nil, countee.pet_count, countee.created_at, countee.updated_at]) %><% end %>
+<%= CSV.generate_line ['ID', t('activerecord.models.counting.one').capitalize, t('activerecord.models.district.one'), t('activerecord.models.gender.one'), t('activerecord.models.age_group.one'), t('activerecord.attributes.countee.pet_count')] %>
+<% @countees.each do |countee| %><%= CSV.generate_line([countee.id, countee.counting.title, countee.district.name, countee.gender.present? ? countee.gender.label : nil, countee.age_group.present? ? countee.age_group.label : nil, countee.pet_count]) %><% end %>

--- a/app/views/countees/index.html.erb
+++ b/app/views/countees/index.html.erb
@@ -25,6 +25,8 @@
   <% end %>
   </ul>
   <% if @pagy.pages > 1 %>
-    <%== pagy_nav(@pagy) %>
+    <div class="mt-8">
+      <%== pagy_nav(@pagy) %>
+    </div>
   <% end %>
 </div>

--- a/app/views/countees/index.html.erb
+++ b/app/views/countees/index.html.erb
@@ -22,4 +22,5 @@
     <% end %>
   <% end %>
   </ul>
+  <%== pagy_nav(@pagy) %>
 </div>

--- a/app/views/countees/index.html.erb
+++ b/app/views/countees/index.html.erb
@@ -11,7 +11,7 @@
   <div class="flex justify-between gap-2">
     <h1 class="text-2xl font-bold pb-2"><%= t('countees.index.title') %></h1>
     <%= render ButtonComponent.new(tag: :a, href: all_counting_countees_path(@counting, format: :csv)) do %>
-      Alle downloaden (CSV)
+      <%= t('countees.all.download') %>
     <% end %>
   </div>
   <ul>

--- a/app/views/countees/index.html.erb
+++ b/app/views/countees/index.html.erb
@@ -8,8 +8,11 @@
 <% content_for(:main_tag_classes) { 'p-5' } %>
 
 <div>
-  <div class="grid grid-cols-1 gap-2">
+  <div class="flex justify-between gap-2">
     <h1 class="text-2xl font-bold pb-2"><%= t('countees.index.title') %></h1>
+    <%= render ButtonComponent.new(tag: :a, href: all_counting_countees_path(@counting, format: :csv)) do %>
+      Alle downloaden (CSV)
+    <% end %>
   </div>
   <ul>
   <% @countees.each do |countee| %>

--- a/app/views/countees/index.html.erb
+++ b/app/views/countees/index.html.erb
@@ -10,8 +10,10 @@
 <div>
   <div class="flex justify-between gap-2">
     <h1 class="text-2xl font-bold pb-2"><%= t('countees.index.title') %></h1>
-    <%= render ButtonComponent.new(tag: :a, href: all_counting_countees_path(@counting, format: :csv)) do %>
-      <%= t('countees.all.download') %>
+    <% unless @counting.countees.empty? %>
+      <%= render ButtonComponent.new(tag: :a, href: all_counting_countees_path(@counting, format: :csv)) do %>
+        <%= t('countees.all.download') %>
+      <% end %>
     <% end %>
   </div>
   <ul>

--- a/app/views/countees/index.html.erb
+++ b/app/views/countees/index.html.erb
@@ -24,5 +24,7 @@
     <% end %>
   <% end %>
   </ul>
-  <%== pagy_nav(@pagy) %>
+  <% if @pagy.pages > 1 %>
+    <%== pagy_nav(@pagy) %>
+  <% end %>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (5.10.1)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Pagy DEFAULT Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::DEFAULT[:page]   = 1                                  # default
+# Pagy::DEFAULT[:items]  = 20                                 # default
+# Pagy::DEFAULT[:outset] = 0                                  # default
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
+# Pagy::DEFAULT[:cycle]      = true                            # example
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each unit
+# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
+#
+# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
+# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
+#
+# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
+# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
+#
+# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
+#
+# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
+# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            items: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the frontend helpers internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/frontend_helpers'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the number of items per page depending on the page number
+# See https://ddnexus.github.io/pagy/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# set to false only if you want to make :items_extra an opt-in variable
+# Pagy::DEFAULT[:items_extra] = false    # default true
+# Pagy::DEFAULT[:items_param] = :items   # default
+# Pagy::DEFAULT[:max_items]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -210,9 +210,7 @@
 #
 # load the "de", "en" and "es" built-in locales:
 # (the first passed :locale will be used also as the default_locale)
-# Pagy::I18n.load({ locale: 'de' },
-#                 { locale: 'en' },
-#                 { locale: 'es' })
+Pagy::I18n.load({ locale: 'de' }, { locale: 'en' })
 #
 # load the "en" built-in locale, a custom "es" locale,
 # and a totally custom locale complete with a custom :pluralize proc:

--- a/config/locales/age_group.de.yml
+++ b/config/locales/age_group.de.yml
@@ -1,0 +1,6 @@
+de:
+  activerecord:
+    models:
+      age_group:
+        one: "Altersgruppe"
+        other: "Altersgruppen"

--- a/config/locales/age_groups.en.yml
+++ b/config/locales/age_groups.en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    models:
+      age_group:
+        one: "Age group"
+        other: "Age groups"

--- a/config/locales/countees.de.yml
+++ b/config/locales/countees.de.yml
@@ -28,6 +28,8 @@ de:
   countees:
     index:
       title: "Gezählte Personen"
+    all:
+      download: "Als CSV herunterladen"
     new:
       title: "Person hinzufügen"
     create:

--- a/config/locales/countees.en.yml
+++ b/config/locales/countees.en.yml
@@ -29,6 +29,8 @@ en:
   countees:
     index:
       title: "Counted people"
+    all:
+      download: "Download as CSV"
     new:
       title: "Add person"
     create:

--- a/config/locales/districts.de.yml
+++ b/config/locales/districts.de.yml
@@ -1,0 +1,6 @@
+de:
+  activerecord:
+    models:
+      district:
+        one: "Bezirke"
+        other: "Bezirke"

--- a/config/locales/districts.en.yml
+++ b/config/locales/districts.en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    models:
+      district:
+        one: "District"
+        other: "Districts"

--- a/config/locales/genders.de.yml
+++ b/config/locales/genders.de.yml
@@ -1,0 +1,6 @@
+de:
+  activerecord:
+    models:
+      gender:
+        one: "Gender"
+        other: "Gender"

--- a/config/locales/genders.en.yml
+++ b/config/locales/genders.en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    models:
+      gender:
+        one: "Gender"
+        other: "Genders"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,12 @@ Rails.application.routes.draw do
 
     # Countings routes
     resources :countings do
-      resources :countees, only: %i[index new create destroy]
+      resources :countees, only: %i[index new create destroy] do
+        collection do
+          # Download-as-CSV route:
+          get :all
+        end
+      end
 
       get 'results/district', to: 'results#district', as: 'district_results'
       get 'results/gender', to: 'results#gender', as: 'gender_results'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@prettier/plugin-ruby": "3.2.2",
+        "@prettier/plugin-ruby": "2.1.0",
         "prettier": "2.7.1"
       }
     },
     "node_modules/@prettier/plugin-ruby": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-ruby/-/plugin-ruby-3.2.2.tgz",
-      "integrity": "sha512-Vc7jVE39Fgswl517ET4kPtpnoRWE6XTi1Sivd84rZyomYnHYUmvUsEeoOf6tVhzTuIXE5XVQB1YCG2hulrwR3Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-ruby/-/plugin-ruby-2.1.0.tgz",
+      "integrity": "sha512-lAoYFoDnwlxM3jl+dS7yrmxD49d3nbKFTBuhHx3VTPoAwmOOKOIO4nRJTTBWF+rS7KUAVn2XPLwRR0Obh/KW6A==",
       "dev": true,
       "dependencies": {
         "prettier": ">=2.3.0"
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@prettier/plugin-ruby": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-ruby/-/plugin-ruby-3.2.2.tgz",
-      "integrity": "sha512-Vc7jVE39Fgswl517ET4kPtpnoRWE6XTi1Sivd84rZyomYnHYUmvUsEeoOf6tVhzTuIXE5XVQB1YCG2hulrwR3Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-ruby/-/plugin-ruby-2.1.0.tgz",
+      "integrity": "sha512-lAoYFoDnwlxM3jl+dS7yrmxD49d3nbKFTBuhHx3VTPoAwmOOKOIO4nRJTTBWF+rS7KUAVn2XPLwRR0Obh/KW6A==",
       "dev": true,
       "requires": {
         "prettier": ">=2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@prettier/plugin-ruby": "3.2.2",
+    "@prettier/plugin-ruby": "2.1.0",
     "prettier": "2.7.1"
   }
 }

--- a/test/controllers/countees_controller_test.rb
+++ b/test/controllers/countees_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'csv'
 
 class CounteesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
@@ -12,6 +13,27 @@ class CounteesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index' do
     get counting_countees_url(@counting, { locale: I18n.locale })
+
+    assert_response :success
+  end
+
+  test 'should download all countees as CSV' do
+    get all_counting_countees_url(
+          @counting,
+          { locale: I18n.locale, format: :csv },
+        )
+
+    assert_equal response.content_type, 'text/csv'
+
+    # We use the parsed CSV for checking if there are as many rows
+    # as there are fixture countees.
+    # If we wanted to improve this test even more,
+    # we could additionally check the contents of each row to see
+    # if it matches the fixture data entries.
+    parsed_csv =
+      CSV.parse(response.parsed_body, headers: true, skip_blanks: true)
+
+    assert_equal parsed_csv.length, @counting.countees.length
 
     assert_response :success
   end


### PR DESCRIPTION
This PR makes the list of countees for each counting downloadable as a CSV (closes #76, closes #58).

## To do:

- [x] first sketch of implementation
- [x] create a readable CSV file name (with I18n in mind)
- [ ] ~~extract what is currently in the CSV template into a helper or PORO (_no business logic in a template_)~~ (not with this PR, the code in the template is short and still readable)
- [x] I18n for CSV contents, UI text, etc.
- [x] add pagination because I wanna test the download with thousands of countees
- [x] slightly improve the styling of the pagination (use Pagy's Tailwind config?)
- [x] add tests