### PR TITLE
feat(#84): enable signing up for countings

### DIFF
--- a/app/controllers/counting_signups_controller.rb
+++ b/app/controllers/counting_signups_controller.rb
@@ -1,0 +1,54 @@
+class CountingSignupsController < ApplicationController
+  before_action :authenticate_admin!, only: %i[index]
+  before_action :authenticate_user!, only: %i[create destroy]
+
+  before_action :set_counting
+  before_action :set_counting_signup
+
+  def index; end
+
+  def create
+    @counting_signup =
+      CountingSignup.new(
+        counting_id: counting_signup_params[:counting_id],
+        user_id: current_user.id,
+      )
+
+    respond_to do |format|
+      if @counting_signup.save
+        format.html do
+          redirect_to counting_url(@counting),
+                      notice: I18n.t('counting_signups.create.notice')
+        end
+      else
+        format.html { render 'countings/show', status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @counting_signup.destroy
+
+    respond_to do |format|
+      format.html do
+        redirect_to counting_url(@counting),
+                    notice: I18n.t('counting_signups.destroy.notice')
+      end
+    end
+  end
+
+  private
+
+  def set_counting
+    @counting = Counting.find(counting_signup_params[:counting_id])
+  end
+
+  def set_counting_signup
+    @counting_signup =
+      @counting.counting_signups.find_by(user_id: current_user.id)
+  end
+
+  def counting_signup_params
+    params.permit(:counting_id)
+  end
+end

--- a/app/controllers/counting_signups_controller.rb
+++ b/app/controllers/counting_signups_controller.rb
@@ -5,7 +5,10 @@ class CountingSignupsController < ApplicationController
   before_action :set_counting
   before_action :set_counting_signup, only: %i[destroy]
 
-  def index; end
+  def index
+    @pagy, @counting_signups =
+      pagy(@counting.counting_signups.order('created_at DESC'))
+  end
 
   def create
     @counting_signup =

--- a/app/controllers/counting_signups_controller.rb
+++ b/app/controllers/counting_signups_controller.rb
@@ -3,14 +3,14 @@ class CountingSignupsController < ApplicationController
   before_action :authenticate_user!, only: %i[create destroy]
 
   before_action :set_counting
-  before_action :set_counting_signup
+  before_action :set_counting_signup, only: %i[destroy]
 
   def index; end
 
   def create
     @counting_signup =
       CountingSignup.new(
-        counting_id: counting_signup_params[:counting_id],
+        counting_id: params[:counting_id],
         user_id: current_user.id,
       )
 
@@ -40,15 +40,10 @@ class CountingSignupsController < ApplicationController
   private
 
   def set_counting
-    @counting = Counting.find(counting_signup_params[:counting_id])
+    @counting = Counting.find(params[:counting_id])
   end
 
   def set_counting_signup
-    @counting_signup =
-      @counting.counting_signups.find_by(user_id: current_user.id)
-  end
-
-  def counting_signup_params
-    params.permit(:counting_id)
+    @counting_signup = @counting.counting_signups.find(params[:id])
   end
 end

--- a/app/helpers/counting_signups_helper.rb
+++ b/app/helpers/counting_signups_helper.rb
@@ -1,0 +1,2 @@
+module CountingSignupsHelper
+end

--- a/app/models/counting.rb
+++ b/app/models/counting.rb
@@ -11,6 +11,8 @@ class Counting < ApplicationRecord
 
   belongs_to :user
 
+  has_many :counting_signups, dependent: :destroy
+
   has_many :countees, dependent: :destroy
 
   scope :past, -> { where('ends_at < ?', Time.now) }

--- a/app/models/counting.rb
+++ b/app/models/counting.rb
@@ -21,4 +21,9 @@ class Counting < ApplicationRecord
   def ongoing?
     Time.now.between? starts_at, ends_at
   end
+
+  MIN_TIME_BEFORE_COUNTING = 7.days
+  def signups_allowed?
+    Time.now.before? starts_at - MIN_TIME_BEFORE_COUNTING
+  end
 end

--- a/app/models/counting_signup.rb
+++ b/app/models/counting_signup.rb
@@ -2,5 +2,12 @@ class CountingSignup < ApplicationRecord
   belongs_to :counting
   belongs_to :user
 
-  validates :user, uniqueness: { scope: :counting }
+  validates :user,
+            uniqueness: {
+              scope: :counting,
+              message:
+                I18n.t(
+                  'activerecord.errors.models.counting_signup.attributes.user.uniqueness',
+                ),
+            }
 end

--- a/app/models/counting_signup.rb
+++ b/app/models/counting_signup.rb
@@ -2,21 +2,5 @@ class CountingSignup < ApplicationRecord
   belongs_to :counting
   belongs_to :user
 
-  validates :user,
-            uniqueness: {
-              scope: :counting,
-              message: 'A user may only signup for a counting once',
-            }
-
-  validate :within_signup_period?
-
-  private
-
-  MIN_TIME_BEFORE_COUNTING = 7.days
-
-  def within_signup_period?
-    unless Time.now.before? counting.starts_at - MIN_TIME_BEFORE_COUNTING
-      errors.add(:created_at, 'is not within signup period')
-    end
-  end
+  validates :user, uniqueness: { scope: :counting }
 end

--- a/app/models/counting_signup.rb
+++ b/app/models/counting_signup.rb
@@ -1,0 +1,22 @@
+class CountingSignup < ApplicationRecord
+  belongs_to :counting
+  belongs_to :user
+
+  validates :user,
+            uniqueness: {
+              scope: :counting,
+              message: 'A user may only signup for a counting once',
+            }
+
+  validate :within_signup_period?
+
+  private
+
+  MIN_TIME_BEFORE_COUNTING = 7.days
+
+  def within_signup_period?
+    unless Time.now.before? counting.starts_at - MIN_TIME_BEFORE_COUNTING
+      errors.add(:created_at, 'is not within signup period')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,14 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
+  devise :database_authenticatable,
+         :registerable,
+         :recoverable,
+         :rememberable,
+         :validatable,
+         :confirmable
 
   has_many :countings, dependent: :destroy
+
+  has_many :counting_signups, dependent: :destroy
 end

--- a/app/views/counting_signups/index.html.erb
+++ b/app/views/counting_signups/index.html.erb
@@ -9,9 +9,20 @@
 
 <div>
   <%= content_tag :h1, t('activerecord.models.counting_signup.other'), class: 'text-4xl' %>
-  <ul>
-    <% @counting.counting_signups.each do |counting_signup| %>
-      <%= content_tag :li, counting_signup.user.email %>
-    <% end %>
-  </ul>
+  <%= content_tag :h2, @counting.title, class: 'mt-2 text-lg text-blue-200' %>
+  <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-2">
+    <div>
+      <ul>
+        <% @counting.counting_signups.each do |counting_signup| %>
+          <%= content_tag :li, counting_signup.user.email, class: 'odd:bg-blue-800 px-3 py-2' %>
+        <% end %>
+      </ul>
+      <% if @pagy.pages > 1 %>
+        <div class="mt-8">
+          <%== pagy_nav(@pagy) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="bg-blue-500 p-5 order-first md:order-none">Map placeholder</div>
+  </div>
 </div>

--- a/app/views/counting_signups/index.html.erb
+++ b/app/views/counting_signups/index.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:header_slot) {
+    render ButtonComponent.new(scheme: :link, tag: :a, href: counting_path(@counting), class: 'p-0') do
+      "← #{t('counting_signups.index.back')}"
+    end
+  }
+%>
+
+<% content_for(:main_tag_classes) { 'p-5' } %>
+
+<div>
+  <%= content_tag :h1, t('activerecord.models.counting_signup.other'), class: 'text-4xl' %>
+  <ul>
+    <% @counting.counting_signups.each do |counting_signup| %>
+      <%= content_tag :li, counting_signup.user.email %>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/countings/show.html.erb
+++ b/app/views/countings/show.html.erb
@@ -14,6 +14,21 @@
     <%= render(Counting::HeaderComponent.new(title: @counting.title, starts_at: @counting.starts_at, ends_at: @counting.ends_at)) do %>
     <% end %>
 
+    <% if current_user && @counting.signups_allowed? %>
+      <div class="mt-4 flex gap-2 justify-end items-center">
+        <% if @counting.counting_signups.find_by(user_id: current_user.id) %>
+          <p class="text-sm text-yellow-400"><%= t('counting_signups.destroy.current_status') %></p>
+          <%= render(ButtonComponent.new(path: counting_counting_signup_path(@counting), type: :submit, method: :delete, scheme: :danger, form: { data: { turbo_confirm: t('counting_signups.destroy.are_you_sure') } })) do %>
+            <%= t('counting_signups.destroy.title')%>
+          <% end %>
+        <% else %>
+          <%= render(ButtonComponent.new(path: counting_counting_signups_path(@counting), type: :submit, method: :post, scheme: :primary)) do %>
+            <%= t('counting_signups.create.title')%>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
     <% if user_signed_in? && @counting.ongoing? %>
       <div class="mt-4">
         <%= render(ButtonComponent.new(tag: :a, href: new_counting_countee_path(@counting), scheme: :primary, class: 'block w-full text-center')) do %>

--- a/app/views/countings/show.html.erb
+++ b/app/views/countings/show.html.erb
@@ -18,7 +18,7 @@
       <div class="mt-4 flex gap-2 justify-end items-center">
         <% if @counting.counting_signups.find_by(user_id: current_user.id) %>
           <p class="text-sm text-yellow-400"><%= t('counting_signups.destroy.current_status') %></p>
-          <%= render(ButtonComponent.new(path: counting_counting_signup_path(@counting), type: :submit, method: :delete, scheme: :danger, form: { data: { turbo_confirm: t('counting_signups.destroy.are_you_sure') } })) do %>
+          <%= render(ButtonComponent.new(path: counting_counting_signup_path(@counting, @counting.counting_signups.find_by(user: current_user.id)), type: :submit, method: :delete, scheme: :danger, form: { data: { turbo_confirm: t('counting_signups.destroy.are_you_sure') } })) do %>
             <%= t('counting_signups.destroy.title')%>
           <% end %>
         <% else %>

--- a/app/views/countings/show.html.erb
+++ b/app/views/countings/show.html.erb
@@ -37,20 +37,20 @@
       </div>
     <% end %>
 
-    <% if user_signed_in? && current_user.admin? %>
-      <div class="mt-4">
-        <%= render(ButtonComponent.new(tag: :a, href: counting_countees_path(@counting), class: 'block w-full text-center')) do %>
-          <%= t('countees.index.title') %>
-        <% end %>
-      </div>
-    <% end %>
-
     <main class="pt-8">
       <%= @counting.description_long %>
     </main>
   </article>
 
   <% if user_signed_in? and current_user.admin? %>
+    <div class="mt-4 flex gap-2 justify-between">
+      <%= render(ButtonComponent.new(tag: :a, href: counting_counting_signups_path(@counting), class: 'block w-full text-center')) do %>
+        <%= t('activerecord.models.counting_signup.other') %>
+      <% end %>
+      <%= render(ButtonComponent.new(tag: :a, href: counting_countees_path(@counting), class: 'block w-full text-center')) do %>
+        <%= t('countees.index.title') %>
+      <% end %>
+    </div>
     <div class="mt-4 block flex justify-center">
       <%= render(ButtonComponent.new(tag: :a, href: edit_counting_path(@counting), scheme: :link, size: :small, class: 'px-0 underline')) do %>
         <%= t('countings.edit.explicitly') %>

--- a/app/views/countings/show.html.erb
+++ b/app/views/countings/show.html.erb
@@ -45,7 +45,7 @@
   <% if user_signed_in? and current_user.admin? %>
     <div class="mt-4 flex gap-2 justify-between">
       <%= render(ButtonComponent.new(tag: :a, href: counting_counting_signups_path(@counting), class: 'block w-full text-center')) do %>
-        <%= t('activerecord.models.counting_signup.other') %>
+        <%= t('activerecord.models.counting_signup.other') %> <%= content_tag :span, @counting.counting_signups.size, class: 'bg-blue-50 text-blue-900 px-1 py-0.5 text-sm rounded-sm' %>
       <% end %>
       <%= render(ButtonComponent.new(tag: :a, href: counting_countees_path(@counting), class: 'block w-full text-center')) do %>
         <%= t('countees.index.title') %>

--- a/config/locales/counting_signups.en.yml
+++ b/config/locales/counting_signups.en.yml
@@ -1,0 +1,26 @@
+en:
+  activerecord:
+    attributes:
+      counting_signup:
+        created_at: "Registration date"
+    models:
+      counting_signups:
+        one: "Registration"
+        other: "Registrations"
+    errors:
+      models:
+        counting_signup:
+          attributes:
+            user:
+              uniqueness: "You are already participating in this counting"
+  counting_signups:
+    index:
+      title: "Registered participants"
+    create:
+      title: "Participate"
+      notice: "You have successfully signed up for this counting"
+    destroy: 
+      current_status: "You are participating in this counting."
+      title: "Withdraw participation"
+      are_you_sure: "Are you sure you want to withdraw your participation in this counting?"
+      notice: "You no longer participate in this counting"

--- a/config/locales/counting_signups.en.yml
+++ b/config/locales/counting_signups.en.yml
@@ -4,7 +4,7 @@ en:
       counting_signup:
         created_at: "Registration date"
     models:
-      counting_signups:
+      counting_signup:
         one: "Registration"
         other: "Registrations"
     errors:
@@ -15,7 +15,7 @@ en:
               uniqueness: "You are already participating in this counting"
   counting_signups:
     index:
-      title: "Registered participants"
+      back: "Back to counting"
     create:
       title: "Participate"
       notice: "You have successfully signed up for this counting"

--- a/config/locales/countings_signups.de.yml
+++ b/config/locales/countings_signups.de.yml
@@ -4,7 +4,7 @@ de:
       counting_signup:
         created_at: "Registrierungsdatum"
     models:
-      counting_signups:
+      counting_signup:
         one: "Registrierung"
         other: "Registrierungen"
     errors:
@@ -15,7 +15,7 @@ de:
               uniqueness: "Du bist bereits für diese Zählung registriert"
   counting_signups:
     index:
-      title: "Registrierte Teilnehmende"
+      back: "Zurück zur Zählung"
     create:
       title: "Teilnehmen"
       notice: "Du wurdest erfolgreich für diese Zählung registriert"

--- a/config/locales/countings_signups.de.yml
+++ b/config/locales/countings_signups.de.yml
@@ -1,0 +1,26 @@
+de:
+  activerecord:
+    attributes:
+      counting_signup:
+        created_at: "Registrierungsdatum"
+    models:
+      counting_signups:
+        one: "Registrierung"
+        other: "Registrierungen"
+    errors:
+      models:
+        counting_signup:
+          attributes:
+            user:
+              uniqueness: "Du bist bereits für diese Zählung registriert"
+  counting_signups:
+    index:
+      title: "Registrierte Teilnehmende"
+    create:
+      title: "Teilnehmen"
+      notice: "Du wurdest erfolgreich für diese Zählung registriert"
+    destroy: 
+      current_status: "Du bist für diese Zählung registriert."
+      title: "Nicht mehr teilnehmen"
+      are_you_sure: "Bist du sicher, dass du deine Teilnahme an dieser Zählung beenden möchtest?"
+      notice: "Du nimmst nicht länger an dieser Zählung teil"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
 
     # Countings routes
     resources :countings do
+      resources :counting_signups, only: %i[index new create destroy]
+
       resources :countees, only: %i[index new create destroy] do
         collection do
           # Download-as-CSV route:

--- a/db/migrate/20221021094556_create_counting_signups.rb
+++ b/db/migrate/20221021094556_create_counting_signups.rb
@@ -1,0 +1,13 @@
+class CreateCountingSignups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :counting_signups do |t|
+      t.references :counting, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+
+      # A user may only signup for a counting once:
+      t.index %i[counting_id user_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_20_130623) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_21_094556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -83,6 +83,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_20_130623) do
     t.index ["counting_id"], name: "index_counting_areas_on_counting_id"
   end
 
+  create_table "counting_signups", force: :cascade do |t|
+    t.bigint "counting_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["counting_id", "user_id"], name: "index_counting_signups_on_counting_id_and_user_id", unique: true
+    t.index ["counting_id"], name: "index_counting_signups_on_counting_id"
+    t.index ["user_id"], name: "index_counting_signups_on_user_id"
+  end
+
   create_table "countings", force: :cascade do |t|
     t.string "title", null: false
     t.text "description_short"
@@ -135,5 +145,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_20_130623) do
   add_foreign_key "countees", "districts"
   add_foreign_key "countees", "genders"
   add_foreign_key "counting_areas", "countings"
+  add_foreign_key "counting_signups", "countings"
+  add_foreign_key "counting_signups", "users"
   add_foreign_key "countings", "users"
 end

--- a/test/controllers/counting_signups_controller_test.rb
+++ b/test/controllers/counting_signups_controller_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+class CountingSignupsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @counting = countings(:future)
+    I18n.locale = :de
+  end
+
+  test 'displays counting_signups to admin user' do
+    sign_in users(:admin)
+
+    get counting_counting_signups_url(
+          counting_id: @counting.id,
+          locale: I18n.locale,
+        )
+    assert_response :success
+  end
+
+  test 'rejects to show counting_signups to regular user' do
+    sign_in users(:regular)
+
+    get counting_counting_signups_url(
+          counting_id: @counting.id,
+          locale: I18n.locale,
+        )
+    assert_response :not_found
+  end
+
+  test 'creates counting_signup when user is not already signed up' do
+    sign_in users(:alice)
+
+    assert_difference('CountingSignup.count') do
+      post counting_counting_signups_url(
+             counting_id: @counting.id,
+             locale: I18n.locale,
+           )
+    end
+
+    assert_redirected_to counting_url(@counting)
+  end
+
+  test 'rejects counting_signup when user is already signed up' do
+    sign_in users(:regular)
+
+    assert_no_difference('CountingSignup.count') do
+      post counting_counting_signups_url(
+             counting_id: @counting.id,
+             locale: I18n.locale,
+           )
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test 'destroys counting_signup of an already registered user' do
+    sign_in users(:regular)
+
+    assert_difference('CountingSignup.count', -1) do
+      delete counting_counting_signup_path(
+               counting_id: @counting,
+               id:
+                 @counting.counting_signups.find_by(
+                   user_id: users(:regular).id,
+                 ),
+             )
+    end
+    assert_redirected_to counting_url(@counting)
+  end
+end

--- a/test/fixtures/counting_signups.yml
+++ b/test/fixtures/counting_signups.yml
@@ -1,0 +1,23 @@
+one:
+  counting: ongoing
+  user: admin
+
+two:
+  counting: ongoing
+  user: regular
+
+three:
+  counting: ongoing
+  user: alice
+
+four:
+  counting: ongoing
+  user: bob
+
+five:
+  counting: future
+  user: regular
+
+six:
+  counting: future
+  user: admin

--- a/test/fixtures/countings.yml
+++ b/test/fixtures/countings.yml
@@ -27,3 +27,10 @@ ongoing:
   starts_at: <%= Time.now %>
   ends_at: <%= Time.now + 7.days %>
   user: admin
+
+future:
+  title: A future counting
+  description_short: This is a counting description_short
+  starts_at: <%= Time.now + 1.month %>
+  ends_at: <%= Time.now + 1.month + 1.day %>
+  user: admin

--- a/test/models/counting_signup_test.rb
+++ b/test/models/counting_signup_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class CountingSignupTest < ActiveSupport::TestCase
+  test 'should reject a signup if user is already signed up for the counting' do
+    # Invalid counting signup because users(:regular) has already signed up via the fixtures:
+    counting_signup =
+      CountingSignup.new(counting: countings(:future), user: users(:regular))
+
+    counting_signup.valid?
+    assert_not counting_signup.errors[:user].empty?,
+               'Expected counting signup to error because [:counting, :user] uniqueness validation was violated'
+  end
+
+  test 'should reject a signup that is outside of the time period for signup' do
+    counting = countings(:future)
+    date_after_signup_period_ended = counting.starts_at - 1.day
+
+    travel_to date_after_signup_period_ended do
+      counting_signup =
+        CountingSignup.new(counting: counting, user: users(:alice))
+
+      counting_signup.valid?
+      assert_not counting_signup.errors[:created_at].empty?,
+                 'Expected counting signup to be invalid because signup period has ended'
+    end
+  end
+
+  test 'should accept signup for an ongoing counting with an existing user' do
+    # users(:alice) is not signed up in the test fixtures:
+    counting_signup =
+      CountingSignup.new(counting: countings(:future), user: users(:alice))
+
+    counting_signup.valid?
+    assert_empty counting_signup.errors, 'Expected errors to be empty'
+  end
+end

--- a/test/models/counting_signup_test.rb
+++ b/test/models/counting_signup_test.rb
@@ -11,20 +11,6 @@ class CountingSignupTest < ActiveSupport::TestCase
                'Expected counting signup to error because [:counting, :user] uniqueness validation was violated'
   end
 
-  test 'should reject a signup that is outside of the time period for signup' do
-    counting = countings(:future)
-    date_after_signup_period_ended = counting.starts_at - 1.day
-
-    travel_to date_after_signup_period_ended do
-      counting_signup =
-        CountingSignup.new(counting: counting, user: users(:alice))
-
-      counting_signup.valid?
-      assert_not counting_signup.errors[:created_at].empty?,
-                 'Expected counting signup to be invalid because signup period has ended'
-    end
-  end
-
   test 'should accept signup for an ongoing counting with an existing user' do
     # users(:alice) is not signed up in the test fixtures:
     counting_signup =


### PR DESCRIPTION
This PR makes sure that users need to sign up for countings before being able to add countees.

- [x] create counting signup resource
- [x] create actions & UI for signing up and destroying a signup
- [x] create route for _admins_ to view signups (route should later be used to assign counting areas to registrations)
- [x] show current number of signups on counting/show page (button for counting_signups/index

---

At a later point we need to think if more users can sign up than counting areas exist, and how people are notified about their assigned counting areas or if they haven't been assigned an area.