### PR TITLE
refactor: use more concide validations

### DIFF
--- a/app/models/countee.rb
+++ b/app/models/countee.rb
@@ -5,41 +5,29 @@ class Countee < ApplicationRecord
   belongs_to :gender, optional: true
   belongs_to :age_group, optional: true
 
-  validate :created_while_counting_ongoing,
-    :gender_is_blank_or_exists,
-    :age_group_is_blank_or_exists
+  validate :created_while_counting_ongoing, on: :create
 
   validates :pet_count,
     numericality: {
       greater_than_or_equal_to: 0
     },
-    unless: -> { pet_count.blank? }
+    allow_nil: true
+
+  validates :gender_id, inclusion: {
+    in: Gender.pluck(:id), message:  I18n.t("activerecord.errors.models.countee.attributes.gender_id.invalid")
+  }, allow_blank: true
+
+  validates :age_group_id, inclusion: {
+    in: AgeGroup.pluck(:id), message:  I18n.t("activerecord.errors.models.countee.attributes.age_group_id.invalid")
+  }, allow_blank: true
 
   private
 
   def created_while_counting_ongoing
     unless counting.ongoing?
-      errors.add :created_at,
+      errors.add :base, :counting_not_ongoing, message:
         I18n.t(
-          "activerecord.errors.models.countee.attributes.created_at"
-        )
-    end
-  end
-
-  def gender_is_blank_or_exists
-    unless gender_id.blank? || Gender.exists?(gender_id)
-      errors.add :gender_id,
-        I18n.t(
-          "activerecord.errors.models.countee.attributes.gender_id.invalid"
-        )
-    end
-  end
-
-  def age_group_is_blank_or_exists
-    unless age_group_id.blank? || AgeGroup.exists?(age_group_id)
-      errors.add :age_group_id,
-        I18n.t(
-          "activerecord.errors.models.countee.attributes.age_group_id.invalid"
+          "activerecord.errors.models.countee.base.counting_not_ongoing"
         )
     end
   end

--- a/config/locales/countees.de.yml
+++ b/config/locales/countees.de.yml
@@ -12,8 +12,9 @@ de:
     errors:
       models:
         countee:
+          base:
+            counting_not_ongoing: "Kann nur während der Zählung hinzugefügt werden"
           attributes:
-            created_at: "Kann nur während der Zählung hinzugefügt werden"
             gender_id:
               invalid: "ungültig"
             age_group_id:

--- a/config/locales/countees.en.yml
+++ b/config/locales/countees.en.yml
@@ -12,8 +12,9 @@ en:
     errors:
       models:
         countee:
+          base:
+            counting_not_ongoing: "Can only be saved during associated counting"
           attributes:
-            created_at: "Can only be saved during associated counting"
             gender_id:
               invalid: "is invalid"
             age_group_id:

--- a/test/models/countee_test.rb
+++ b/test/models/countee_test.rb
@@ -4,7 +4,7 @@ class CounteeTest < ActiveSupport::TestCase
   test "should not be able to create countee for a concluded counting" do
     countee = Countee.new(counting: countings(:concluded))
     countee.valid?
-    assert_not countee.errors[:created_at].empty?
+    assert countee.errors.any?
   end
 
   test "should be able to create countee during ongoing counting" do


### PR DESCRIPTION
This PR reafctors the `Countee` model validations to use validations that are more Rails-y.