### PR TITLE
chore: remove outdated scope for District

### DIFF
--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -3,20 +3,4 @@ class District < ApplicationRecord
   validates :name, :geometry, presence: true
 
   has_many :countees
-
-  scope :contains_point?,
-    ->(latitude, longitude) {
-      unless latitude.is_a?(Float) && longitude.is_a?(Float)
-        raise ArgumentError, "Please provide floats as params"
-      end
-      if latitude.present? && longitude.present?
-        District.where(
-          [
-            "ST_Contains(geometry::geometry, ST_GeomFromText('POINT (? ?)', 4326))",
-            longitude,
-            latitude
-          ]
-        )
-      end
-    }
 end

--- a/test/models/district_test.rb
+++ b/test/models/district_test.rb
@@ -25,24 +25,4 @@ class DistrictTest < ActiveSupport::TestCase
     assert_empty district.errors[:name]
     assert_empty district.errors[:geometry]
   end
-
-  test "should find a district when passed a point within its boundaries" do
-    containing_districts = District.contains_point?(52.522422, 13.391679) # Point is Ebertsbrücke in Berlin
-    assert_equal containing_districts.count,
-      1,
-      "Point can only be in one district at a time"
-
-    assert_equal containing_districts.first.name,
-      districts(:mitte).name,
-      "Tested point lies within area of fixture Mitte district (Ebertsbrücke)"
-  end
-
-  test "should not find a district with point outside Berlin" do
-    containing_districts = District.contains_point?(52.400028, 13.067697) # Point is in Potsdam
-    assert_empty containing_districts
-  end
-
-  test "contains_point? raises error with invalid params" do
-    assert_raises(ArgumentError) { District.contains_point?(nil, "hello") }
-  end
 end


### PR DESCRIPTION
This PR removes dead code that was once used but is now obsolete because requirements changed.