### PR TITLE
feat: only show assignments link when allowed

### DIFF
--- a/app/models/counting.rb
+++ b/app/models/counting.rb
@@ -26,4 +26,8 @@ class Counting < ApplicationRecord
   def signups_allowed?
     Time.now.before? starts_at - 7.days
   end
+
+  def area_assignments_allowed?
+    !signups_allowed? && Time.now.before?(starts_at) && !ongoing?
+  end
 end

--- a/app/views/countings/_counting.html.erb
+++ b/app/views/countings/_counting.html.erb
@@ -35,8 +35,10 @@
     <hr class="mt-8 mb-4 border border-dotted h-px">
     <h2><%= t('common.admin_area') %></h2>
     <div class="mt-4 flex gap-2 justify-between">
-      <%= render(ButtonComponent.new(tag: :a, href: counting_counting_areas_path(counting), class: 'block w-full text-center')) do %>
-        <%= t('activerecord.models.counting_area.other') %>
+      <% if counting.area_assignments_allowed? %>
+        <%= render(ButtonComponent.new(tag: :a, href: counting_counting_areas_path(counting), class: 'block w-full text-center')) do %>
+          <%= t('activerecord.models.counting_area.other') %>
+        <% end %>
       <% end %>
       <%= render(ButtonComponent.new(tag: :a, href: counting_countees_path(counting), class: 'block w-full text-center')) do %>
         <%= t('countees.index.title') %>

--- a/test/models/counting_test.rb
+++ b/test/models/counting_test.rb
@@ -38,4 +38,34 @@ class CountingTest < ActiveSupport::TestCase
     assert_empty counting.errors[:starts_at]
     assert_empty counting.errors[:ends_at]
   end
+
+  test "informs about its ongoing status" do
+    counting =
+      Counting.new(
+        title: "I am a title",
+        starts_at: Time.now - 1.day,
+        ends_at: Time.now + 2.days
+      )
+    assert counting.ongoing?
+  end
+
+  test "informs about its signup period" do
+    counting =
+      Counting.new(
+        title: "I am a title",
+        starts_at: Time.now + 14.days,
+        ends_at: Time.now + 15.days
+      )
+    assert counting.signups_allowed?
+  end
+
+  test "informs about its area assignment period" do
+    counting =
+      Counting.new(
+        title: "I am a title",
+        starts_at: Time.now + 3.days,
+        ends_at: Time.now + 4.days
+      )
+    assert counting.area_assignments_allowed?
+  end
 end


### PR DESCRIPTION
Noe that we could do proper validations to ensure no area assignments are coming through. However, this is an increment and in reality it would certainly not be an issue if there would really be an accidental assignment.