### PR TITLE
docs: install Mermaid ERD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ node_modules
 
 # Test coverage results
 coverage
+
+# ERD diagrams
+mermaid_erd

--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,9 @@ group :development do
 
   # RubyCritic for code quality
   gem "rubycritic", require: false
+
+  # ERD diagrams
+  gem "rails-mermaid_erd"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-mermaid_erd (0.4.2)
+      rails (>= 5.2)
     railties (7.0.6)
       actionpack (= 7.0.6)
       activesupport (= 7.0.6)
@@ -408,6 +410,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2)
+  rails-mermaid_erd
   redis (~> 5.0)
   rgeo-geojson
   rubocop-rails


### PR DESCRIPTION
This PR installs Mermaid ERD. Locally, an ERD diagram is now available via `bundle exec rails mermaid_erd`.