### PR TITLE
feat: only allow counting signup in signup period

### DIFF
--- a/app/models/counting_signup.rb
+++ b/app/models/counting_signup.rb
@@ -13,6 +13,16 @@ class CountingSignup < ApplicationRecord
         )
     }
 
+  validate :signup_allowed
+
+  def signup_allowed
+    unless counting.signups_allowed?
+      errors.add :base, I18n.t(
+        "activerecord.errors.models.counting_signup.attributes.base.signups_disallowed"
+      )
+    end
+  end
+
   def user_email_and_area_count
     "#{user.email} (#{area_assignments.count} #{I18n.t("activerecord.models.area_assignment.other")})"
   end

--- a/config/locales/counting_signups.en.yml
+++ b/config/locales/counting_signups.en.yml
@@ -11,6 +11,8 @@ en:
       models:
         counting_signup:
           attributes:
+            base:
+              signups_disallowed: "currently not permitted"
             user:
               uniqueness: "You are already participating in this counting"
   counting_signups:

--- a/config/locales/countings_signups.de.yml
+++ b/config/locales/countings_signups.de.yml
@@ -11,6 +11,8 @@ de:
       models:
         counting_signup:
           attributes:
+            base:
+              signups_disallowed: "aktuell nicht erlaubt"
             user:
               uniqueness: "Du bist bereits für diese Zählung registriert"
   counting_signups:

--- a/test/fixtures/countings.yml
+++ b/test/fixtures/countings.yml
@@ -34,3 +34,10 @@ future:
   starts_at: <%= Time.now + 1.month %>
   ends_at: <%= Time.now + 1.month + 1.day %>
   user: admin
+
+starting_tomorrow:
+  title: A future counting starting tomorrow
+  description_short: This is a counting description_short
+  starts_at: <%= Time.now + 1.day %>
+  ends_at: <%= Time.now + 2.days %>
+  user: admin

--- a/test/models/counting_signup_test.rb
+++ b/test/models/counting_signup_test.rb
@@ -19,4 +19,13 @@ class CountingSignupTest < ActiveSupport::TestCase
     counting_signup.valid?
     assert_empty counting_signup.errors, "Expected errors to be empty"
   end
+
+  test "should reject signup when outside of allowed signup period" do
+    counting_starting_tomorrow = countings(:starting_tomorrow)
+
+    counting_signup = CountingSignup.new(counting: counting_starting_tomorrow)
+
+    counting_signup.valid?
+    assert counting_signup.errors[:base].present?, "Expected signup to be invalid because outside of allowed signup period"
+  end
 end


### PR DESCRIPTION
This PR ensures that no counting signup is made after the signup period has completed. This was already not offered in the UI. With this change we make sure that the validations will disallow any signup.